### PR TITLE
fix pkgconf_client_new from const void* to void*

### DIFF
--- a/src/compiler/platform/pkg_config.c
+++ b/src/compiler/platform/pkg_config.c
@@ -24,7 +24,7 @@ typedef struct PKG_ERROR_HANDLER_DATA_STRUCT {
     Token_T* token;
 } PkgErrorHandlerData_T;
 
-static bool pkg_error_handler(const char* msg, const pkgconf_client_t* client, const void *raw_data) {
+static bool pkg_error_handler(const char* msg, const pkgconf_client_t* client, void *raw_data) {
     if(!raw_data)
         return false;
     PkgErrorHandlerData_T* data = (PkgErrorHandlerData_T*) raw_data;


### PR DESCRIPTION
In the new pkgconf, in the pkgconf_error_handler_func_t function, the third argument is void*, not const void*.
Without this fix, the build failed (Void linux)

https://github.com/pkgconf/pkgconf/blob/444846dd2dfc9e3a5ea4904826c1c7a4b9b5589b/libpkgconf/libpkgconf.h#L186C1-L187C1